### PR TITLE
Allocate VString buffer for IntermediateAggs

### DIFF
--- a/SOURCES/include/hll_vertica.hpp
+++ b/SOURCES/include/hll_vertica.hpp
@@ -3,6 +3,7 @@
 
 #include "hll.hpp"
 #include "Vertica.h"
+#include "BuildInfo.h"
 
 #define HLL_ARRAY_SIZE_PARAMETER_NAME "hllLeadingBits"
 #define HLL_ARRAY_SIZE_DEFAULT_VALUE 4
@@ -17,5 +18,11 @@ using HLL = Hll<uint64_t>;
 Format formatCodeToEnum(uint8_t f);
 int readSubStreamBits(ServerInterface &srvInterface);
 Format readSerializationFormat(ServerInterface &srvInterface);
+
+constexpr int majorSdkVersion(const char *version)
+{
+	/* support only 0-99 major version*/
+	return (version[1] == '.') ? version[0] - '0' : version[0] * 10 + version[1];
+}
 
 #endif

--- a/SOURCES/src/HllCreateSynopsis.cpp
+++ b/SOURCES/src/HllCreateSynopsis.cpp
@@ -32,7 +32,10 @@ class HllCreateSynopsis : public AggregateFunction
         HLL initialHll(hllLeadingBits);
         this -> synopsisSize = initialHll.getSynopsisSize(format);
         try {
-          initialHll.serialize(aggs.getStringRef(0).data(), format);
+          VString &vs = aggs.getStringRef(0);
+          if (majorSdkVersion(VERTICA_BUILD_ID_SDK_Version) >= 8)
+            vs.alloc(this -> synopsisSize);
+          initialHll.serialize(vs.data(), format);
         } catch(SerializationError& e) {
           vt_report_error(0, e.what());
         }

--- a/SOURCES/src/HllDistinctCount.cpp
+++ b/SOURCES/src/HllDistinctCount.cpp
@@ -31,7 +31,10 @@ class HllDistinctCount : public AggregateFunction
         HLL initialHll(hllLeadingBits);
         this -> synopsisSize = initialHll.getSynopsisSize(format);
         try {
-          initialHll.serialize(aggs.getStringRef(0).data(), format);
+          VString &vs = aggs.getStringRef(0);
+          if (majorSdkVersion(VERTICA_BUILD_ID_SDK_Version) >= 8)
+            vs.alloc(this -> synopsisSize);
+          initialHll.serialize(vs.data(), format);
         } catch(SerializationError& e) {
           vt_report_error(0, e.what());
         }


### PR DESCRIPTION
thus fix the integration test issue with Vertica version >= 8 on RHEL7