### PR TITLE
Makefile.standalone: can be used to created a standalone (lib/libvert…

### DIFF
--- a/SOURCES/src/Makefile.standalone
+++ b/SOURCES/src/Makefile.standalone
@@ -1,0 +1,16 @@
+OBJS:=bias_corrected_estimate.o linear_counting.o  murmur3_hash.o
+CXXFLAGS:=-Ofast -I../include/
+
+all: $(OBJS)
+	ar rcs ../lib/libverticahll.a $(OBJS) 
+
+.o: .cpp
+
+clean:
+	rm -f $(OBJS) ../lib/libverticahll.a
+
+.PHONY: clean prepare
+
+
+
+


### PR DESCRIPTION
It just includes a new Makefile that can be used to build a Hll library without integration hooks.
Use it like so:
`make -f Makefile.standalone`